### PR TITLE
refactor prepXfer and postXfer

### DIFF
--- a/src/plugins/hf3fs/hf3fs_backend.h
+++ b/src/plugins/hf3fs/hf3fs_backend.h
@@ -42,6 +42,7 @@ class nixlHf3fsIO {
         void* orig_addr;  // Original memory address for copying after read
         size_t size;      // Size of the buffer
         bool is_read;     // Whether this is a read operation
+        size_t offset;    // Offset in the file
 
         nixlHf3fsIO() : fd(-1), orig_addr(nullptr), size(0), is_read(false) {}
         ~nixlHf3fsIO() {}

--- a/src/plugins/hf3fs/hf3fs_backend.h
+++ b/src/plugins/hf3fs/hf3fs_backend.h
@@ -48,17 +48,10 @@ class nixlHf3fsIO {
         ~nixlHf3fsIO() {}
 };
 
-enum nixlHf3fsStatus {
-    NIXL_HF3FS_STATUS_PENDING,
-    NIXL_HF3FS_STATUS_PREPARED,
-    NIXL_HF3FS_STATUS_POSTED
-};
-
 class nixlHf3fsBackendReqH : public nixlBackendReqH {
     public:
        std::list<nixlHf3fsIO *> io_list;
        hf3fs_ior ior;
-       nixlHf3fsStatus status;
 
        nixlHf3fsBackendReqH() {}
        ~nixlHf3fsBackendReqH() {}

--- a/src/plugins/hf3fs/hf3fs_backend.h
+++ b/src/plugins/hf3fs/hf3fs_backend.h
@@ -70,6 +70,7 @@ class nixlHf3fsEngine : public nixlBackendEngine {
         hf3fsUtil                      *hf3fs_utils;
         std::unordered_map<int, hf3fsFileHandle> hf3fs_file_map;
 
+        void cleanupIOList(nixlHf3fsBackendReqH *handle);
     public:
         nixlHf3fsEngine(const nixlBackendInitParams* init_params);
         ~nixlHf3fsEngine();


### PR DESCRIPTION
Refactor prepXfer and postXfer by moving the createIOR, createIOV and data copy to prepXfer.

Also, added some error handling during failure to clean up handle and io objects.